### PR TITLE
Add Colors to Tailwind Config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,17 @@ module.exports = {
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        projects: {
+          blue: "#82AAFF",
+          purple: "#C792E9",
+          red: "#FF5370",
+          orange: "#F88C6B",
+          green: "#80CBC3",
+        },
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
I added all of our custom colors to the tail wind config. They can be accessed using the `projects` prefix, so `projects-green` to get the green color.